### PR TITLE
Update permission check

### DIFF
--- a/generators/app/templates/src/utils/index.js
+++ b/generators/app/templates/src/utils/index.js
@@ -12,9 +12,8 @@ function* entries(obj) {
 }
 
 function checkAppPermissions(userAppPermissions, appPermissions) {
-  const userAppPermission = userAppPermissions.sort().toString();
-  const appPermission = appPermissions.sort().toString();
-  return userAppPermission === appPermission;
+  return appPermissions.every(permission => userAppPermissions.includes(permission))
+
 }
 
 export {


### PR DESCRIPTION
Check if all necessary permissions are included instead of equality. For instance following will return true now, while previously returning false: `checkAppPermissions([READ, WRITE], [READ])`