### PR TITLE
remove the reset form button from the form model renderer and its log…

### DIFF
--- a/generators/app/templates/src/containers/FormModel/Renderer/form-renderer.component.js
+++ b/generators/app/templates/src/containers/FormModel/Renderer/form-renderer.component.js
@@ -88,18 +88,14 @@ const FormModelRenderer = () => {
    * Submit function for the form, to do the conversion and set up the output
    * This function is for the view button
    */
-  const onSubmit = useCallback((e: Event) => {
+  async function onSubmit(e: Event) {
     e.preventDefault();
+    await setSubmitted(null);
     let obj = {};
     if (schemaUrl !== '') obj = { ...obj, schemaUrl };
     if (source !== '') obj = { ...obj, source };
     setSubmitted(obj);
-  });
-
-  const resetModel = useCallback(() => {
-    setViewMode(true);
-    setSubmitted(null);
-  });
+  }
 
   /**
    * Change event for the source
@@ -218,9 +214,6 @@ const FormModelRenderer = () => {
               >
                 {t('formLanguage.renderer.editBtn')}
               </Button>
-              <button type="button" onClick={resetModel}>
-                {t('formLanguage.renderer.resetBtn')}
-              </button>
             </div>
           </ResultHeader>
         </Result>


### PR DESCRIPTION
…ic, now on click generate after changing the schema or source, it automatically resets the form builder without the extra step of manually reset it.