### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Once the generator is installed, you can create a new application with just a fe
    3. A version number.
    4. Whether the application is private or public.
 4. Navigate into the new folder.
-5. If you would like to start the application, simply run ``` npm run start ``` in the new folder, otherwise you can begin editing and writing your application!
+5. If you would like to start the application, simply run ```npm install``` and then ``` npm run start ``` in the new folder, otherwise you can begin editing and writing your application!
    1. If you would like to run the application in HTTPS mode, you can run the command ```HTTPS=true npm start```, which will launch your app on localhost, using the HTTPS protocol.
 
 Note: We have noticed an error is sometimes thrown when the generator tries to install one of the dependencies of application. If this occurs, try installing [Git](https://git-scm.com/downloads) and then recreating your application.


### PR DESCRIPTION
I needed to run ```npm install``` before ```npm run start```, so I added that to the README.md - not sure if that's totally correct or not - if not, just ignore this (and tell me what I'm doing wrong!) - here is the error I was seeing:
```
[myFifthApp]$ npm run start

> solid-app@0.1.0 start /home/pmcb55/Work/Projects/Solid/ReactSdk/myFifthApp
> node scripts/start.js

internal/modules/cjs/loader.js:638
    throw err;
    ^

Error: Cannot find module 'dotenv-expand'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at dotenvFiles.forEach.dotenvFile (/home/pmcb55/Work/Projects/Solid/ReactSdk/myFifthApp/config/env.js:32:5)
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/home/pmcb55/Work/Projects/Solid/ReactSdk/myFifthApp/config/env.js:30:13)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! solid-app@0.1.0 start: `node scripts/start.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the solid-app@0.1.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/pmcb55/.npm/_logs/2019-11-15T12_26_06_420Z-debug.log
```