### PR TITLE
Adjust jest testMatch to work cross platform

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -72,7 +72,7 @@
     ],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-      "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}"
+      "<rootDir>/src/**/*(*.)@(spec|test).{js,jsx,ts,tsx}"
     ],
     "testEnvironment": "jsdom",
     "testURL": "http://localhost",


### PR DESCRIPTION
before this change running tests (npm run test) returns 'No tests found' on windows.
As per [jest issue #7914 #issuecomment-464352069](https://github.com/facebook/jest/issues/7914#issuecomment-464352069) changing the [micromatch](https://github.com/micromatch/micromatch#extglobs) glob works on both OS's.
There is a proposed solution but the jest code has not changed in that location.