### PR TITLE
Adding i18n support to rendered forms

### DIFF
--- a/generators/app/templates/src/containers/FormModel/Renderer/form-renderer.component.js
+++ b/generators/app/templates/src/containers/FormModel/Renderer/form-renderer.component.js
@@ -6,7 +6,7 @@ import { Select, Loader } from '@util-components';
 import ldflex from '@solid/query-ldflex';
 
 import { RendererTypesList, ConverterTypes } from '@constants';
-import { successToaster, errorToaster } from '@utils';
+import { successToaster, errorToaster, languageHelper } from '@utils';
 import {
   FormModelContainer,
   FormWrapper,
@@ -42,6 +42,7 @@ const FormModelRenderer = () => {
     item => t(`formLanguage.${item}`) === t('formLanguage.formModel')
   );
   const optionsList = filteredOptions.map(item => t(`formLanguage.${item}`));
+  const language = languageHelper.getLanguageCode();
 
   /**
    * Helper function to detect if choice is ShEx
@@ -129,12 +130,13 @@ const FormModelRenderer = () => {
     // Set boolean to disable or enable the layout/extension textbox
     setHasLayoutFile(hasLayout(newValue));
     setSelectedInput(newValue);
-    console.log(selectedInput);
   });
 
   const onError = e => {
-    console.log(e);
-    if (e.message.toString().indexOf('Validation failed') < 0) {
+    if (
+      e.message.toString().indexOf('Validation failed') < 0 ||
+      e.message.toString().indexOf('Error rendering Form Model') < 0
+    ) {
       errorToaster(t('formLanguage.renderer.formNotLoaded'), t('notifications.error'), {
         label: t('errorFormRender.link.label'),
         href: t('errorFormRender.link.href')
@@ -248,7 +250,8 @@ const FormModelRenderer = () => {
                     },
                     autosaveIndicator: AutoSaveSpinner,
                     autosave: true,
-                    viewer: isViewMode
+                    viewer: isViewMode,
+                    language
                   }
                 }}
               />

--- a/generators/app/templates/src/containers/Profile/profile.container.js
+++ b/generators/app/templates/src/containers/Profile/profile.container.js
@@ -2,7 +2,7 @@ import React, { Fragment, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { FormModel } from '@inrupt/solid-react-components';
-import { successToaster, errorToaster } from '@utils';
+import { successToaster, errorToaster, languageHelper } from '@utils';
 import { Loader } from '@util-components';
 import {
   Header,
@@ -16,6 +16,7 @@ import { Image } from './components';
 import { AutoSaveSpinner } from '@components';
 
 const defaultProfilePhoto = '/img/icon/empty-profile.svg';
+const language = languageHelper.getLanguageCode();
 
 /**
  * We are using ldflex to fetch profile data from a solid pod.
@@ -102,7 +103,8 @@ const Profile = ({ webId }: Props) => {
                       childGroup: 'inrupt-form-group'
                     },
                     autosave: true,
-                    autosaveIndicator: AutoSaveSpinner
+                    autosaveIndicator: AutoSaveSpinner,
+                    language
                   }
                 }}
                 liveUpdate

--- a/generators/app/templates/src/utils/index.js
+++ b/generators/app/templates/src/utils/index.js
@@ -5,6 +5,7 @@ import * as ldflexHelper from './ldflex-helper';
 import * as notification from './notification';
 import * as storageHelper from './storage';
 import * as permissionHelper from './permissions';
+import * as languageHelper from './language';
 
 function* entries(obj) {
   for (const key of Object.keys(obj)) {
@@ -21,5 +22,6 @@ export {
   successToaster,
   errorToaster,
   notification,
-  permissionHelper
+  permissionHelper,
+  languageHelper
 };

--- a/generators/app/templates/src/utils/language.js
+++ b/generators/app/templates/src/utils/language.js
@@ -1,0 +1,13 @@
+/**
+ * Helper function to get language string from i18n library
+ * @returns {string}
+ */
+export const getLanguageCode =  () => {
+  let language = localStorage.getItem('i18nextLng') || 'en';
+
+  // Quick fix for an issue where the i18n library sometimes uses en-US instead of en
+  if(language === 'en-US') {
+    language = 'en'
+  }
+  return language;
+}


### PR DESCRIPTION
* Added new language helper to get the language code from localstorage
* Fetched the language code and passed it into the form renderer page
* Also updated the profile page's form to use language as well