### PR TITLE
Fixed Multiple and Group rendering

### DIFF
--- a/generators/app/templates/src/containers/FormModel/Renderer/form-renderer.component.js
+++ b/generators/app/templates/src/containers/FormModel/Renderer/form-renderer.component.js
@@ -240,15 +240,16 @@ const FormModelRenderer = () => {
                   onDelete: response => onDelete(response),
                   options: {
                     theme: {
+                      form: 'inrupt-sdk-form',
                       inputText: 'input-wrap',
                       inputCheckbox: 'sdk-checkbox checkbox',
-                      form: 'inrupt-sdk-form',
-                      childGroup: 'inrupt-form-group',
                       singleLine: 'input-wrap',
                       integerField: 'input-wrap',
                       decimalInput: 'input-wrap',
                       floatField: 'input-wrap',
-                      checkboxField: 'input-wrap'
+                      checkboxField: 'input-wrap',
+                      groupField: 'group-wrapper',
+                      multipleField: 'multiple-wrapper'
                     },
                     autosaveIndicator: AutoSaveSpinner,
                     autosave: true,

--- a/generators/app/templates/src/containers/FormModel/form-model.style.js
+++ b/generators/app/templates/src/containers/FormModel/form-model.style.js
@@ -30,13 +30,18 @@ export const FormWrapper = styled.div`
     h3 {
       margin: 14px 0px;
     }
+
+    // This is to turn off the border of the form. Since groups have borders, and the outer form is considered a group, we want
+    // to remove the border in this special case of the group being a direct child of the form class
+    & > .group-wrapper {
+      border: none;
+    }
   }
 
-  .inrupt-form-group {
+  .multiple-wrapper {
     border: 1px solid #c0c0c0;
-    background-color: #f9f9f9;
     margin: 15px 0;
-    padding: 6px;
+    padding: 12px;
 
     button {
       display: block;
@@ -51,6 +56,13 @@ export const FormWrapper = styled.div`
       width: 100%;
       margin-bottom: 10px;
     }
+  }
+
+  // Add border and padding to group components, for visual separation
+  .group-wrapper {
+    border: 1px solid #c0c0c0;
+    padding: 12px;
+    margin: 12px 0;
   }
 
   input {
@@ -151,7 +163,7 @@ export const FormRenderContainer = styled.div`
   .inrupt-sdk-form {
     div > div > div {
       display: inline-block;
-      width: 95%;
+      width: 100%;
     }
   }
 `;

--- a/generators/app/templates/src/containers/Profile/profile.container.js
+++ b/generators/app/templates/src/containers/Profile/profile.container.js
@@ -100,7 +100,9 @@ const Profile = ({ webId }: Props) => {
                       inputText: 'input-wrap',
                       inputCheckbox: 'sdk-checkbox checkbox',
                       form: 'inrupt-sdk-form',
-                      childGroup: 'inrupt-form-group'
+                      childGroup: 'inrupt-form-group',
+                      groupField: 'group-wrapper',
+                      multipleField: 'multiple-wrapper'
                     },
                     autosave: true,
                     autosaveIndicator: AutoSaveSpinner,


### PR DESCRIPTION
Added in missing classes and CSS for rendering Multiples and Groups. Now each Mutliple has a box around all items inside of it, and each Group has a box around it as well. Nested groups render as expected, and no longer rely on Multiples being parents.