### PR TITLE
Implemented temporary fix for OIDC-compliance logout issue

### DIFF
--- a/generators/app/templates/src/components/AuthNavBar/children/NavbarProfile/nav-bar-profile.component.js
+++ b/generators/app/templates/src/components/AuthNavBar/children/NavbarProfile/nav-bar-profile.component.js
@@ -87,10 +87,25 @@ class NavBarProfile extends Component<Props> {
   logOut = async () => {
     try {
       await auth.logout();
+
+      let logoutRedirect = "/login"
+      // It seems that solid-auth-client has an OIDC-compliance issue in the logout.
+      // This bevahiour is accepted by the NSS IdP, but not by other OIDC-compliant IdPs.
+      // This issue should be fixed in the upstream library, but in the meantime
+      // the following is an acceptable **temporary** compatibility fix.
+      const authConfig = JSON.parse(localStorage.getItem('solid-auth-client'))
+      // It happens that post_logout_redirect_uris is not defined by NSS IdP,
+      // which enables discriminating when the issue is going to be encountered.
+      if(authConfig.rpConfig.registration.post_logout_redirect_uris) {
+        // The user MUST be redirected to a page where they confirm they want to logout.
+        logoutRedirect = authConfig.rpConfig.provider.configuration.end_session_endpoint
+      }
+
       // Remove localStorage
       localStorage.removeItem('solid-auth-client');
-      // Redirect to login page
-      window.location = '/login';
+
+      // Redirect to login page or to logout confirmation
+      window.location = logoutRedirect;
     } catch (error) {
       errorToaster(error.message, 'Error');
     }


### PR DESCRIPTION
The logout implementation of `solid-auth-client` makes assumptions that break the OIDC compliance, which prevents from logging out of OIDC-compliant identity providers. A proper fix should be implemented upstream in `solid-auth-client`, but in the meantime this enables properly logging user out. 