### PR TITLE
Adding missing yeoman-script setting

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -40,6 +40,8 @@ const fileList = [
     { src: 'src/services/**', dest: 'src/services' },
     // UTILS
     { src: 'src/utils/**', dest: 'src/utils' },
+    // VOCABS
+    { src: 'src/vocabs/**', dest: 'src/vocabs' },
     // DEFAULT CONTAINERS
     { src: 'src/containers/Login/**', dest: 'src/containers/Login' },
     {


### PR DESCRIPTION
* With the new vocabs folder, it must be added to the yeoman startup script or it will not be added to the user's generated application